### PR TITLE
Poprawa logiki logowania dla nieautoryzowanych domen

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -3,7 +3,8 @@ import {
   signInWithPopup,
   GoogleAuthProvider,
   onAuthStateChanged,
-  signOut
+  signOut,
+  deleteUser
 } from "firebase/auth";
 import { auth } from "@services/firebase.js";
 
@@ -25,7 +26,7 @@ export function AuthProvider({ children }) {
         allowedEmails.includes(email);
 
       if (!isAllowed) {
-        await signOut(auth);
+        await deleteUser(result.user);
         throw new Error("restricted-domain");
       }
     } catch (error) {


### PR DESCRIPTION
Zmieniono logikę logowania. Od teraz system usuwa konta użytkowników próbujących zalogować się z nieautoryzowanych domen, zamiast jedynie ich wylogowywać. 

Rozwiązuje to problem z ostrzeżeniami o wygasającym wsparciu z konsoli Firebase.

Closes #64