### PR TITLE
Naprawa ciemnego motywu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-campus",
-  "version": "0.1.0",
+  "version": "0.1-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "smart-campus",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1-beta.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -8,6 +8,7 @@ export const useTheme = () => {
   useEffect(() => {
     const root = document.documentElement;
     root.style.setProperty('color-scheme', theme);
+    root.setAttribute('data-theme', theme);
     localStorage.setItem('colorScheme', theme);
   }, [theme]);
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,4 +20,7 @@ export default defineConfig({
       '@icons': path.resolve(__dirname, './src/assets/icons'),
     },
   },
+  build: {
+    cssTarget: 'chrome123'
+  }
 })


### PR DESCRIPTION
Vite próbował tworzyć kod kompatybilny wstecz. W ustawieniach bundlera została dodana klauzura aby tworzył kod dla nowych przeglądarek.  
close #87 