### PR TITLE
Fix: Naprawa bluru w LandingNavBar (#107)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smart-campus",
-  "version": "0.3",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smart-campus",
-      "version": "0.1-beta.3",
+      "version": "0.3.1",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^7.2.0",
         "@fortawesome/free-brands-svg-icons": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "smart-campus",
   "private": true,
-  "version": "0.3",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/LandingNavBar/LandingNavBar.css
+++ b/src/components/LandingNavBar/LandingNavBar.css
@@ -12,8 +12,10 @@
     align-items: center;
     justify-content: space-between;
     padding: 0 20px;
-    backdrop-filter: blur(20px);
-    -webkit-backdrop-filter: blur(20px);
+    backdrop-filter: blur(15px);
+    -webkit-backdrop-filter: blur(15px);
+    transform: translateZ(0);
+    will-change: transform, backdrop-filter;
     border: 1px solid light-dark(rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.1));
     box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
     z-index: 100;
@@ -87,8 +89,10 @@
     width: calc(100% - 40px);
     box-sizing: border-box;
     background-color: light-dark(rgba(255, 255, 255, 0.60), rgba(24, 52, 71, 0.60));
-    backdrop-filter: blur(20px);
-    -webkit-backdrop-filter: blur(20px);
+    backdrop-filter: blur(15px);
+    -webkit-backdrop-filter: blur(15px);
+    transform: translateZ(0);
+    will-change: transform, backdrop-filter;
     border: 1px solid light-dark(rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.1));
     box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
     border-radius: 26px;

--- a/system_wdrazania_wersji.md
+++ b/system_wdrazania_wersji.md
@@ -1,0 +1,38 @@
+# Ostateczny System Wersjonowania - Smart Campus (Wersja v7)
+
+Upraszczamy wszystko do perfekcji! Usunąłem daty i godziny, aby nie komplikować niepotrzebnie procesu (pamiętając, że Git i tak sam trzyma czas każdego zapisu). Zostawiamy czysty, uporządkowany system oparty na numerach i literkach, a w gałęziach używamy słówka "upcoming".
+
+## 1. Nazewnictwo Wersji (Format X.Y.Z)
+
+Baza to zawsze **`X.Y.Z`** (Major.Minor.Patch). Wersja ma być zawsze pisana jednym ciągiem znaków.
+
+* **Format 1: Czysty Standard (Nowe wydania i standardowe poprawki)**
+  * *Schemat:* `X.Y.Z`
+  * *Przykład:* `0.4.0`, `0.4.1`
+  * *Kiedy używać:* Dla normalnych wydań i standardowych, większych poprawek. Zmiana liczby oznacza, że do aplikacji weszła widoczna nowość lub duża łata.
+
+* **Format 2: Wariant Literowy (Poprawki do poprawek - Hotfix)**
+  * *Schemat:* `X.Y.Z[litera]` (Litera jest *przyklejona* do ostatniej cyfry, zero spacji i myślników)
+  * *Przykład:* `0.4.1a`, `0.4.1b`
+  * *Kiedy używać:* Wydałeś `0.4.1`, ale okazało się, że jest tam jakaś literówka lub drobny błąd, który trzeba załatać w 5 minut. Zamiast zużywać kolejny numer (0.4.2), wydajesz mikropoprawkę `0.4.1a`. Kolejny taki mikrobłąd? `0.4.1b`.
+
+---
+
+## 2. Nazywanie Gałęzi Roboczych (Słówko `upcoming`)
+Skoro rezygnujemy z wpisywania wersji w nazwy gałęzi (żeby uniknąć zamieszania, bo plany co do wersji potrafią się zmienić), wprowadzamy uniwersalne słówko oznaczające "nadchodzącą wersję":
+
+* **Zadania i Nowości do nowej wersji:** `upcoming/`
+  * *Przykład:* `upcoming/mapa-kampusu`
+* **Poprawki i Łatki:** `fix/`
+  * *Przykład:* `fix/przycisk-logowania`
+
+*Dzięki takiemu nazewnictwu, patrząc na listę gałęzi od razu wiesz co to jest. Gdy gałąź skończy swoje zadanie i zostanie wgrana do głównego kanału, gałąź tę po prostu usuwamy, bo jej praca "wsiąka" w aplikację i czeka na wydanie z odpowiednim numerem.*
+
+---
+
+## 3. Kanały Dystrybucji
+Kanały pozostają Twoimi torami publikacji (czyli 3 głównymi gałęziami, które trwają wiecznie):
+
+* 🔵 **Dev (`dev`)** - Kod roboczy, poligon doświadczalny zespołu.
+* 🟠 **Public Beta (`beta`)** - Przetestowane nowości trafiają tu, aby mogli sprawdzić je zaproszeni studenci.
+* 🟢 **Main (`main`)** - Kod kuloodporny dla każdego. Najczęściej widnieją tu wersje bez literowych dopisków (np. `0.4.0`).


### PR DESCRIPTION
Rozwiązuje problem zgłoszony w #107.

**Co zostało zrobione:**
- Dodano `transform: translateZ(0);` oraz `will-change: transform, backdrop-filter;` do elementów `.titleBar` oraz `.titleBar_mobileMenu` w pliku `LandingNavBar.css`.
- Poprawka ta wymusza na przeglądarce osobną warstwę renderowania dla navbara, co jest wymaganym krokiem do działania własności `backdrop-filter` w niektórych przypadkach w przeglądarkach opartych na silniku Blink (jak np. Google Chrome), kiedy elementy mają pozycję `fixed`.

Zamykam: #107